### PR TITLE
Make django-historicalrecords compatible with 1.4

### DIFF
--- a/src/history/models.py
+++ b/src/history/models.py
@@ -1,5 +1,9 @@
 import copy
-import datetime
+
+try:
+    from django.utils import timezone as datetime
+except:
+    from datetime import datetime as datetime
 
 from django.db import models
 
@@ -67,7 +71,7 @@ class HistoricalRecords(object):
         rel_nm = '_%s_history' % model._meta.object_name.lower()
         return {
             'history_id': models.AutoField(primary_key=True),
-            'history_date': models.DateTimeField(default=datetime.datetime.now),
+            'history_date': models.DateTimeField(default=datetime.now()),
             'history_type': models.CharField(max_length=1, choices=(
                 ('+', 'Created'),
                 ('~', 'Changed'),


### PR DESCRIPTION
When django-historicalrecords is used with Django 1.4 the following Warning will be raised "RuntimeWarning: DateTimeField received a naive datetime (2012-01-01 00:00:00) while time zone support is active."

This is because of the new timezone support in Django, to fix this problem instead of datetime django.utils.timezone should be used to get the current time.

This is fixed by first trying to import django.utils.timezone, if this doesn't work use datetime for backwards compatibility.
